### PR TITLE
Fixed Package.swift - now can be added without any problem

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.3
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version: 5.3
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
         .library(name: "UserAgency", targets: ["UserAgency"])
     ],
     targets: [
-        .target(name: "UserAgency", dependencies: []),
-        .testTarget(name: "UserAgencyTests", dependencies: ["UserAgency"])
+        .target(name: "UserAgency", dependencies: [], path: "UserAgency"),
+        .testTarget(name: "UserAgencyTests", dependencies: ["UserAgency"], path: "UserAgencyTests")
     ],
     swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
Xcode complained about missing manifest. Paths must have been fixed to rule out this. Also added toolkit version.